### PR TITLE
🐛 Resolvendo bug relacionado à variável de ambiente vinculada ao banc…

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,6 +2,6 @@ import os
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 SECRET_KEY = os.getenv('SECRET_KEY_FLASK')
-SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URI', 'sqlite:///database.db')
+SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL').replace('postgres://', 'postgresql://')
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 DEBUG = os.getenv('DEBUG', False)


### PR DESCRIPTION
…o de dados, que gerava um erro devido ao SQLAlchemy utilizar "postgresql://" em vez de "postgres://", como é automaticamente fornecido pelo provedor de nuvem.